### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0](https://github.com/ipetkov/shock/releases/tag/v0.1.0) - 2023-09-17
 
 ### Other
-- update Cargo.toml metadata
-- add release-plz
-- Update README
-- Add README
-- *(deps)* bump actions/checkout from 3 to 4
-- add actions config
-- Fix verbose printing of ignored snapshots
-- Add NixOS module
-- Update
-- restructure
-- Add application name to the flake definition
-- Add anyhow
-- Sort snapshots in reverse creation time
-- Add some tests
-- Enable verbose logging
-- Implement calculating which snapshots to destroy
-- Implement reading a configuration file
-- Add clap
-- Add config module
-- Initial commit
+- Initial release


### PR DESCRIPTION
## 🤖 New release
* `shock`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/ipetkov/shock/releases/tag/v0.1.0) - 2023-09-17

### Other
- update Cargo.toml metadata
- add release-plz
- Update README
- Add README
- *(deps)* bump actions/checkout from 3 to 4
- add actions config
- Fix verbose printing of ignored snapshots
- Add NixOS module
- Update
- restructure
- Add application name to the flake definition
- Add anyhow
- Sort snapshots in reverse creation time
- Add some tests
- Enable verbose logging
- Implement calculating which snapshots to destroy
- Implement reading a configuration file
- Add clap
- Add config module
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).