### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/ipetkov/shock/compare/v0.1.0...v0.1.1) - 2023-09-17
+
+### Other
+- Update README
+- fix token for flake updates
+- *(deps)* bump toml from 0.7.8 to 0.8.0 ([#5](https://github.com/ipetkov/shock/pull/5))
+- *(deps)* bump clap from 4.4.2 to 4.4.3 ([#4](https://github.com/ipetkov/shock/pull/4))
+- add workflow to update flake.lock
+- enable dependabot for cargo
+- Run release-plz only after tests have passed
+- release v0.1.0 ([#2](https://github.com/ipetkov/shock/pull/2))
+
 ## [0.1.0](https://github.com/ipetkov/shock/releases/tag/v0.1.0) - 2023-09-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "shock"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shock"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = """


### PR DESCRIPTION
## 🤖 New release
* `shock`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/ipetkov/shock/compare/v0.1.0...v0.1.1) - 2023-09-17

### Other
- Update README
- fix token for flake updates
- *(deps)* bump toml from 0.7.8 to 0.8.0 ([#5](https://github.com/ipetkov/shock/pull/5))
- *(deps)* bump clap from 4.4.2 to 4.4.3 ([#4](https://github.com/ipetkov/shock/pull/4))
- add workflow to update flake.lock
- enable dependabot for cargo
- Run release-plz only after tests have passed
- release v0.1.0 ([#2](https://github.com/ipetkov/shock/pull/2))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).