### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/ipetkov/shock/compare/v0.1.1...v0.1.2) - 2023-10-01
+
+### Other
+- *(deps)* bump clap from 4.4.3 to 4.4.6 ([#9](https://github.com/ipetkov/shock/pull/9))
+- *(deps)* bump toml from 0.8.0 to 0.8.1 ([#8](https://github.com/ipetkov/shock/pull/8))
+- update gh cli flag
+- also delete branch after merging flake updates
+- enable auto approve of flake updates if they pass tests
+
 ## [0.1.1](https://github.com/ipetkov/shock/compare/v0.1.0...v0.1.1) - 2023-09-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "shock"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shock"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = """


### PR DESCRIPTION
## 🤖 New release
* `shock`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/ipetkov/shock/compare/v0.1.1...v0.1.2) - 2023-10-01

### Other
- *(deps)* bump clap from 4.4.3 to 4.4.6 ([#9](https://github.com/ipetkov/shock/pull/9))
- *(deps)* bump toml from 0.8.0 to 0.8.1 ([#8](https://github.com/ipetkov/shock/pull/8))
- update gh cli flag
- also delete branch after merging flake updates
- enable auto approve of flake updates if they pass tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).