### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/ipetkov/shock/compare/v0.1.4...v0.1.5) - 2023-11-05
+
+### Fixed
+- *(systemd)* disable PrivateUsers since it breaks with zfs 2.2.0
+
+### Other
+- *(deps)* bump all cargo dependencies
+- *(flake)* remove unnecessary follows clause
+- *(flake)* Update flake.lock
+
 ## [0.1.4](https://github.com/ipetkov/shock/compare/v0.1.3...v0.1.4) - 2023-11-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "shock"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shock"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 description = """


### PR DESCRIPTION
## 🤖 New release
* `shock`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/ipetkov/shock/compare/v0.1.4...v0.1.5) - 2023-11-05

### Fixed
- *(systemd)* disable PrivateUsers since it breaks with zfs 2.2.0

### Other
- *(deps)* bump all cargo dependencies
- *(flake)* remove unnecessary follows clause
- *(flake)* Update flake.lock
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).