### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/ipetkov/shock/compare/v0.1.7...v0.1.8) - 2024-02-01
+
+### Other
+- *(deps)* bump clap from 4.4.12 to 4.4.18 ([#39](https://github.com/ipetkov/shock/pull/39))
+- *(deps)* bump anyhow from 1.0.78 to 1.0.79 ([#37](https://github.com/ipetkov/shock/pull/37))
+- *(deps)* bump toml from 0.8.8 to 0.8.9 ([#36](https://github.com/ipetkov/shock/pull/36))
+- *(flake)* Update flake.lock
+
 ## [0.1.7](https://github.com/ipetkov/shock/compare/v0.1.6...v0.1.7) - 2024-01-01
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "shock"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shock"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 license = "MIT"
 description = """


### PR DESCRIPTION
## 🤖 New release
* `shock`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.8](https://github.com/ipetkov/shock/compare/v0.1.7...v0.1.8) - 2024-02-01

### Other
- *(deps)* bump clap from 4.4.12 to 4.4.18 ([#39](https://github.com/ipetkov/shock/pull/39))
- *(deps)* bump anyhow from 1.0.78 to 1.0.79 ([#37](https://github.com/ipetkov/shock/pull/37))
- *(deps)* bump toml from 0.8.8 to 0.8.9 ([#36](https://github.com/ipetkov/shock/pull/36))
- *(flake)* Update flake.lock
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).