### PR TITLE
chore: release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/ipetkov/shock/compare/v0.1.10...v0.1.11) - 2024-05-03
+
+### Other
+- *(flake)* Update flake.lock
+- *(deps)* bump serde from 1.0.197 to 1.0.199 ([#58](https://github.com/ipetkov/shock/pull/58))
+- *(deps)* bump anyhow from 1.0.81 to 1.0.82 ([#59](https://github.com/ipetkov/shock/pull/59))
+
 ## [0.1.10](https://github.com/ipetkov/shock/compare/v0.1.9...v0.1.10) - 2024-04-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "shock"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shock"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 license = "MIT"
 description = """


### PR DESCRIPTION
## 🤖 New release
* `shock`: 0.1.10 -> 0.1.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.11](https://github.com/ipetkov/shock/compare/v0.1.10...v0.1.11) - 2024-05-03

### Other
- *(flake)* Update flake.lock
- *(deps)* bump serde from 1.0.197 to 1.0.199 ([#58](https://github.com/ipetkov/shock/pull/58))
- *(deps)* bump anyhow from 1.0.81 to 1.0.82 ([#59](https://github.com/ipetkov/shock/pull/59))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).